### PR TITLE
Add concurrent read limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "static",
     "deploy",
     "assets"
-  ]
+  ],
+  "dependencies": {
+    "semaphore": "^1.0.3"
+  }
 }


### PR DESCRIPTION
You may or may not want this and that's fine either way. As is, the plugin was OOMing the node process by opening too many read streams at once. : (

Totally possible there's a better, depless way to do this in nodejs too. I don't write much nodejs these days. Semaphores are adorable and this seemed like the perfect excuse. async.queue looks popular for this sort of thing too
