### PR TITLE
Make preserveSourceMaps option work with hashType: 'file'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,16 @@ module.exports = function(grunt) {
           {src: ['test/fixtures/**/*'], dest: 'tmp/rename_files'}
         ]
       },
+      rename_files_with_source_maps: {
+        options: {
+          assetMap: 'tmp/rename_files_with_source_maps/test-assetmap.json',
+          hashType: 'file',
+          preserveSourceMaps: true
+        },
+        files: [
+          {src: ['test/fixtures/**'], dest: 'tmp/rename_files_with_source_maps'}
+        ]
+      }
     },
 
     // Unit tests.

--- a/test/asset_hash_test.js
+++ b/test/asset_hash_test.js
@@ -102,6 +102,20 @@ exports.asset_hash = {
     test.ok(fs.existsSync('tmp/rename_files/test/fixtures/testing.js.2a440ce824809f040dfe6de7bc6099f1.map'));
 
     test.done();
-  }
+  },
+  rename_files_with_source_maps: function(test) {
+    test.expect(6);
 
+    var actual = grunt.file.read('tmp/rename_files_with_source_maps/test-assetmap.json');
+    var expected = grunt.file.read('test/expected/rename_files_with_source_maps/assetmap.json');
+    test.equal(actual, expected, 'should contain a valid asset map.');
+
+    test.ok(fs.existsSync('tmp/rename_files_with_source_maps/test/fixtures/123.5ba48b6e5a7c4d4930fda256f411e55b'));
+    test.ok(fs.existsSync('tmp/rename_files_with_source_maps/test/fixtures/test.279d97c58278ae0309eb0cf24cbeef67.css'));
+    test.ok(fs.existsSync('tmp/rename_files_with_source_maps/test/fixtures/test.279d97c58278ae0309eb0cf24cbeef67.css.map'));
+    test.ok(fs.existsSync('tmp/rename_files_with_source_maps/test/fixtures/testing.fa6a5a3224d7da66d9e0bdec25f62cf0.js'));
+    test.ok(fs.existsSync('tmp/rename_files_with_source_maps/test/fixtures/testing.fa6a5a3224d7da66d9e0bdec25f62cf0.js.map'));
+
+    test.done();
+  }
 };

--- a/test/expected/rename_files_with_source_maps/assetmap.json
+++ b/test/expected/rename_files_with_source_maps/assetmap.json
@@ -1,0 +1,7 @@
+{
+  "test/fixtures/123": "tmp/rename_files_with_source_maps/test/fixtures/123.5ba48b6e5a7c4d4930fda256f411e55b",
+  "test/fixtures/test.css": "tmp/rename_files_with_source_maps/test/fixtures/test.279d97c58278ae0309eb0cf24cbeef67.css",
+  "test/fixtures/test.css.map": "tmp/rename_files_with_source_maps/test/fixtures/test.279d97c58278ae0309eb0cf24cbeef67.css.map",
+  "test/fixtures/testing.js": "tmp/rename_files_with_source_maps/test/fixtures/testing.fa6a5a3224d7da66d9e0bdec25f62cf0.js",
+  "test/fixtures/testing.js.map": "tmp/rename_files_with_source_maps/test/fixtures/testing.fa6a5a3224d7da66d9e0bdec25f62cf0.js.map"
+}


### PR DESCRIPTION
This lets you use `hashType: 'file'` in conjunction with `preserveSourceMaps: true`, which results in source maps that include the same hash as the corresponding file:

```
testing.fa6a5a3224d7da66d9e0bdec25f62cf0.js
testing.fa6a5a3224d7da66d9e0bdec25f62cf0.js.map
```

Right now if you use these options together, source map filenames are simply unchanged.
