### PR TITLE
Support a move option that deletes the original files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In your project's Gruntfile, add a section named `asset_hash` to the data object
 grunt.initConfig({
   asset_hash: {
     options: {
+      move: false,                // Set to true to move instead of copy the source files
       preserveSourceMaps: false,  // Set to true when assets should share the same location as their source map.
       assetMap: 'assetmap.json',  // A mapping file between assets and their hashed locations. Set to `false` to skip generating.
       hashLength: 32,             // Number of hex characters in the hash folder. (0 means no hashing is done).

--- a/tasks/asset_hash.js
+++ b/tasks/asset_hash.js
@@ -113,6 +113,11 @@ module.exports = function(grunt) {
       var relativeDestPath = stripPrefixAndNormalise(destPath, options.destBasePath);
 
       grunt.file.copy(assetPath, destPath);
+
+      if (options.move && assetPath !== destPath) {
+        grunt.file.delete(assetPath);
+      }
+
       assetFileMapping[relativeAssetPath] = relativeDestPath;
       grunt.log.writeln('Copied asset: ' + assetPath + ' -> ' + destPath);
 
@@ -124,6 +129,11 @@ module.exports = function(grunt) {
             relativeDestSourceMapPath = stripPrefixAndNormalise(destSourceMapPath, options.destBasePath);
 
         grunt.file.copy(sourceMapPath, destSourceMapPath);
+
+        if (options.move && sourceMapPath !== destSourceMapPath) {
+          grunt.file.delete(sourceMapPath);
+        }
+
         sourceFileMapping[relativeSourceMapPath] = relativeDestSourceMapPath;
         grunt.log.writeln('Copied source map: ' + destSourceMapPath);
       }


### PR DESCRIPTION
If the source and destination file are different, and this option is enabled, the original file is removed.

I'm not sure how best to set up tests for this option, since moving files out of `test/fixtures` seems... bad. Help / tips appreciated.
